### PR TITLE
Add / index endpoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ inst_reqs = [
     "asyncpg",
     "morecantile~=1.2.0",
     "email-validator",
-    "asyncstdlib",
 ]
 extra_reqs = {
     "test": ["pytest", "pytest-cov", "pytest-asyncio", "requests"],

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ inst_reqs = [
     "asyncpg",
     "morecantile~=1.2.0",
     "email-validator",
+    "asyncstdlib",
 ]
 extra_reqs = {
     "test": ["pytest", "pytest-cov", "pytest-asyncio", "requests"],

--- a/timvt/app.py
+++ b/timvt/app.py
@@ -3,7 +3,7 @@
 import logging
 
 from . import settings, version
-from .endpoints import demo, health, tiles, tms
+from .endpoints import demo, health, tiles, tms, index
 from .events import create_start_app_handler, create_stop_app_handler
 
 from fastapi import FastAPI
@@ -37,3 +37,4 @@ app.include_router(health.router)
 app.include_router(tiles.router)
 app.include_router(tms.router)
 app.include_router(demo.router)
+app.include_router(index.router)

--- a/timvt/app.py
+++ b/timvt/app.py
@@ -30,6 +30,7 @@ if settings.CORS_ORIGINS:
     )
 
 app.add_middleware(GZipMiddleware, minimum_size=0)
+
 app.add_event_handler("startup", create_start_app_handler(app))
 app.add_event_handler("shutdown", create_stop_app_handler(app))
 

--- a/timvt/endpoints/demo.py
+++ b/timvt/endpoints/demo.py
@@ -2,15 +2,37 @@
 
 from ..templates.factory import web_template
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Path
 
 from starlette.requests import Request
-from starlette.responses import HTMLResponse
+from starlette.responses import HTMLResponse, JSONResponse
 
 router = APIRouter()
 
 
 @router.get("/", response_class=HTMLResponse, tags=["demo"])
-def demo(request: Request, template=Depends(web_template)):
+def index(
+    request: Request, template=Depends(web_template),
+):
+    context = {"index": request.app.state.Catalog.index}
+    return template(request, "index.html", context)
+
+
+@router.get("/demo/{table}/", response_class=HTMLResponse, tags=["demo"])
+def demo(
+    request: Request,
+    table: str = Path(..., description="Table Name"),
+    template=Depends(web_template),
+):
     """Demo."""
-    return template(request, "index.html")
+    table_idx = request.app.state.Catalog.get_table(table)
+    if table_idx is None:
+        error = {"error": "Table not found"}
+        return JSONResponse(content=error, status_code=404)
+
+    for route in request.scope["router"].routes:
+        if route.name == "tile_3857":
+            tile_path = route.path.format(table=table, x="{x}", y="{y}", z="{z}")
+
+    context = {"table": table, "tile_path": tile_path}
+    return template(request, "demo.html", context)

--- a/timvt/endpoints/demo.py
+++ b/timvt/endpoints/demo.py
@@ -14,6 +14,7 @@ router = APIRouter()
 def index(
     request: Request, template=Depends(web_template),
 ):
+    """ Return index to OpenAPI docs, Table Metadata, and Demo Pages """
     context = {"index": request.app.state.Catalog.index}
     return template(request, "index.html", context)
 
@@ -24,7 +25,7 @@ def demo(
     table: str = Path(..., description="Table Name"),
     template=Depends(web_template),
 ):
-    """Demo."""
+    """Demo for each table."""
     table_idx = request.app.state.Catalog.get_table(table)
     if table_idx is None:
         error = {"error": "Table not found"}

--- a/timvt/endpoints/index.py
+++ b/timvt/endpoints/index.py
@@ -1,0 +1,86 @@
+"""TiVTiler.index: Index endpoint."""
+
+import json
+from typing import Dict
+
+from asyncpg.pool import Pool
+
+from ..ressources.enums import MimeTypes
+from ..ressources.responses import TileResponse
+from ..utils.dependencies import _get_db_pool
+
+from fastapi import APIRouter, Depends
+
+router = APIRouter()
+
+
+async def index(db_pool: Pool) -> Dict:
+    """Get list of available layers."""
+
+    sql_query = f"""
+        WITH geo_tables AS (
+            SELECT
+                f_table_schema,
+                f_table_name,
+                f_geometry_column
+            FROM
+                geometry_columns
+        ), t AS (
+        SELECT
+            f_table_schema,
+            f_table_name,
+            f_geometry_column,
+            jsonb_object(
+                array_agg(column_name),
+                array_agg(udt_name)
+            ) as coldict
+        FROM
+            information_schema.columns,
+            geo_tables
+        WHERE
+            f_table_schema=table_schema
+            AND
+            f_table_name=table_name
+        GROUP BY
+            f_table_schema,
+            f_table_name,
+            f_geometry_column
+        )
+        SELECT
+            jsonb_agg(
+                jsonb_build_object(
+                    f_table_name,
+                    jsonb_build_object(
+                        'schema', f_table_schema,
+                        'table', f_table_name,
+                        'geometry_column', f_geometry_column,
+                        'columns', coldict
+                    )
+                )
+            )
+        FROM t
+        ;
+    """
+
+    async with db_pool.acquire() as conn:
+        q = await conn.prepare(sql_query)
+        content = await q.fetchval()
+
+    j = json.loads(content)
+    assoc = {}
+    for rec in j:
+        for k, v in rec.items():
+            assoc[k] = v
+
+    return assoc
+
+
+@router.get("/index")
+async def display_index(
+    db_pool: Pool = Depends(_get_db_pool),
+) -> TileResponse:
+    assoc = await index(db_pool)
+    return TileResponse(
+        bytes(json.dumps(assoc), encoding="utf8"),
+        media_type=MimeTypes.json.value,
+    )

--- a/timvt/endpoints/index.py
+++ b/timvt/endpoints/index.py
@@ -1,88 +1,21 @@
 """TiVTiler.index: Index endpoint."""
 
-import json
-import asyncstdlib
-from typing import Dict
+from typing import Any, Dict
 
-from asyncpg.pool import Pool
-
-from ..ressources.enums import MimeTypes
-from ..ressources.responses import TileResponse
-from ..utils.dependencies import _get_db_pool
-
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
 
 router = APIRouter()
 
-
-@asyncstdlib.lru_cache()
-async def index(db_pool: Pool) -> Dict:
-    """Get list of available layers."""
-
-    sql_query = f"""
-        WITH geo_tables AS (
-            SELECT
-                f_table_schema,
-                f_table_name,
-                f_geometry_column
-            FROM
-                geometry_columns
-        ), t AS (
-        SELECT
-            f_table_schema,
-            f_table_name,
-            f_geometry_column,
-            jsonb_object(
-                array_agg(column_name),
-                array_agg(udt_name)
-            ) as coldict
-        FROM
-            information_schema.columns,
-            geo_tables
-        WHERE
-            f_table_schema=table_schema
-            AND
-            f_table_name=table_name
-        GROUP BY
-            f_table_schema,
-            f_table_name,
-            f_geometry_column
-        )
-        SELECT
-            jsonb_agg(
-                jsonb_build_object(
-                    f_table_name,
-                    jsonb_build_object(
-                        'schema', f_table_schema,
-                        'table', f_table_name,
-                        'geometry_column', f_geometry_column,
-                        'columns', coldict
-                    )
-                )
-            )
-        FROM t
-        ;
-    """
-
-    async with db_pool.acquire() as conn:
-        q = await conn.prepare(sql_query)
-        content = await q.fetchval()
-
-    j = json.loads(content)
-    assoc = {}
-    for rec in j:
-        for k, v in rec.items():
-            assoc[k] = v
-
-    return assoc
+params: Dict[str, Any] = {
+    "responses": {200: {"content": {"application/json": {}}}},
+    "response_class": JSONResponse,
+    "tags": ["Index"],
+}
 
 
-@router.get("/index")
+@router.get("/index", **params)
 async def display_index(
-    db_pool: Pool = Depends(_get_db_pool),
-) -> TileResponse:
-    assoc = await index(db_pool)
-    return TileResponse(
-        bytes(json.dumps(assoc), encoding="utf8"),
-        media_type=MimeTypes.json.value,
-    )
+    request: Request,
+) -> JSONResponse:
+    return JSONResponse(content=request.app.state.Catalog.index)

--- a/timvt/endpoints/index.py
+++ b/timvt/endpoints/index.py
@@ -18,4 +18,5 @@ params: Dict[str, Any] = {
 async def display_index(
     request: Request,
 ) -> JSONResponse:
+    """ Return JSON with available table metadata. """
     return JSONResponse(content=request.app.state.Catalog.index)

--- a/timvt/endpoints/index.py
+++ b/timvt/endpoints/index.py
@@ -1,6 +1,7 @@
 """TiVTiler.index: Index endpoint."""
 
 import json
+import asyncstdlib
 from typing import Dict
 
 from asyncpg.pool import Pool
@@ -14,6 +15,7 @@ from fastapi import APIRouter, Depends
 router = APIRouter()
 
 
+@asyncstdlib.lru_cache()
 async def index(db_pool: Pool) -> Dict:
     """Get list of available layers."""
 

--- a/timvt/endpoints/tiles.py
+++ b/timvt/endpoints/tiles.py
@@ -1,7 +1,6 @@
 """TiVTiler.endpoints.tiles: Vector Tiles endpoint."""
 
 from typing import Any, Dict
-
 from asyncpg.pool import Pool
 
 from ..ressources.enums import MimeTypes
@@ -9,9 +8,9 @@ from ..ressources.responses import TileResponse
 from ..settings import MAX_FEATURES_PER_TILE, TILE_BUFFER, TILE_RESOLUTION
 from ..utils.dependencies import TileParams, _get_db_pool
 from ..utils.timings import Timer
-from .index import index
+from fastapi import APIRouter, Depends, Request, Path
+from fastapi.responses import JSONResponse
 
-from fastapi import APIRouter, Depends, Path
 
 router = APIRouter()
 
@@ -22,19 +21,21 @@ params: Dict[str, Any] = {
 }
 
 
-@router.get("/tiles/{table}/{z}/{x}/{y}\\.pbf", **params)
-@router.get("/tiles/{identifier}/{table}/{z}/{x}/{y}\\.pbf", **params)
+@router.get("/tiles/{table}/{z}/{x}/{y}.pbf", name="tile_3857", **params)
+@router.get("/tiles/{identifier}/{table}/{z}/{x}/{y}.pbf", **params)
 async def tile(
+    request: Request,
     table: str = Path(..., description="Table Name"),
     tile_params: TileParams = Depends(),
     db_pool: Pool = Depends(_get_db_pool),
+    columns: str = None,
 ) -> TileResponse:
     """Handle /tiles requests."""
-
-    idx = await index(db_pool)
-    if table not in idx:
-        raise Exception("Table not found")
-    geometry_column = idx[table]["geometry_column"]
+    table_idx = request.app.state.Catalog.get_table(table)
+    if table_idx is None:
+        error = {"error": "Table not found"}
+        return JSONResponse(content=error, status_code=404)
+    geometry_column = table_idx["geometry_column"]
 
     timings = []
     headers: Dict[str, str] = {}
@@ -43,7 +44,17 @@ async def tile(
     epsg = tile_params.tms.crs.to_epsg()
     segSize = (bbox.xmax - bbox.xmin) / 4
 
-    limit = f"LIMIT $9" if MAX_FEATURES_PER_TILE > -1 else ""
+    limitval = str(int(MAX_FEATURES_PER_TILE))
+    cols = table_idx["columns"]
+    if geometry_column in cols:
+        del cols[geometry_column]
+    if columns is not None:
+        include_cols = [c.strip() for c in columns.split(",")]
+        for c in cols.copy():
+            if c not in include_cols:
+                del cols[c]
+    colstring = ", ".join(list(cols))
+    limit = f"LIMIT {limitval}" if MAX_FEATURES_PER_TILE > -1 else ""
     sql_query = f"""
         WITH
         bounds AS (
@@ -65,7 +76,7 @@ async def tile(
                 bounds.geom,
                 $7,
                 $8
-            ) AS geom, *
+            ) AS geom, {colstring}
             FROM "{table}" t, bounds
             WHERE ST_Intersects(
                 ST_Transform(t.geom, 4326), ST_Transform(bounds.geom, 4326)
@@ -86,7 +97,6 @@ async def tile(
                 segSize,  # 6
                 TILE_RESOLUTION,  # 7
                 TILE_BUFFER,  # 8
-                MAX_FEATURES_PER_TILE,  # 9
             )
     timings.append(("db-read", t.elapsed))
 

--- a/timvt/endpoints/tiles.py
+++ b/timvt/endpoints/tiles.py
@@ -79,7 +79,7 @@ async def tile(
                 $7,
                 $8
             ) AS geom, {colstring}
-            FROM "{table}" t, bounds
+            FROM {table} t, bounds
             WHERE ST_Intersects(
                 ST_Transform(t.geom, 4326), ST_Transform(bounds.geom, 4326)
             ) {limit}

--- a/timvt/events.py
+++ b/timvt/events.py
@@ -3,6 +3,7 @@
 from typing import Callable
 
 from .db.events import close_db_connection, connect_to_db
+from .utils.catalog import Catalog
 
 from fastapi import FastAPI
 
@@ -11,7 +12,10 @@ def create_start_app_handler(app: FastAPI) -> Callable:  # type: ignore
     """App start event."""
 
     async def start_app() -> None:
+        global Tables
         await connect_to_db(app)
+        app.state.Catalog = Catalog(app)
+        await app.state.Catalog.init()
 
     return start_app
 

--- a/timvt/settings.py
+++ b/timvt/settings.py
@@ -29,9 +29,13 @@ DB_MAX_INACTIVE_CONN_LIFETIME = config(
     "DB_MAX_INACTIVE_CONN_LIFETIME", cast=float, default=300.0
 )
 
-DATABASE_URL = f"postgresql://{POSTGRES_USER}:{POSTGRES_PASS}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DBNAME}"
+DATABASE_URL = (
+    f"postgresql://{POSTGRES_USER}:"
+    f"{POSTGRES_PASS}@{POSTGRES_HOST}:"
+    f"{POSTGRES_PORT}/{POSTGRES_DBNAME}"
+)
 
-TILE_RESOLUTION = config("DB_MAX_QUERIES", cast=int, default=4096)
+TILE_RESOLUTION = config("TILE_RESOLUTION", cast=int, default=4096)
 TILE_BUFFER = config("TILE_BUFFER", cast=int, default=256)
 MAX_FEATURES_PER_TILE = config("MAX_FEATURES_PER_TILE", cast=int, default=10000)
 

--- a/timvt/templates/demo.html
+++ b/timvt/templates/demo.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset='utf-8' />
+  <title>Ti VTiler</title>
+  <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+
+  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.js'></script>
+  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.css' rel='stylesheet' />
+
+  <link href='https://api.mapbox.com/mapbox-assembly/v0.23.2/assembly.min.css' rel='stylesheet'>
+  <script src='https://api.mapbox.com/mapbox-assembly/v0.23.2/assembly.js'></script>
+
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+    }
+
+    #map {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 100%;
+    }
+  </style>
+</head>
+
+<body>
+  <div id='map'></div>
+  <script>
+
+    const endpoint = window.location.protocol + '//' + window.location.host + '{{ tile_path }}' + window.location.search;
+    const table = '{{ table }}'
+
+    var scope = { metadata: {}, config: {} }
+
+    var map = new mapboxgl.Map({
+      container: 'map',
+      style: { version: 8, sources: {}, layers: [] },
+      center: [0, 0],
+      zoom: 4
+    })
+
+    map.on('load', () => {
+      map.addSource('table', {
+        type: 'vector',
+        tiles:[
+          endpoint
+        ],
+        minzoom: 4,
+        maxzoom: 24
+      })
+      map.addLayer({
+        id: 'table',
+        source: 'table',
+        'source-layer': 'default',
+        type: 'fill',
+        paint: {
+          'fill-color': 'rgba(200, 100, 240, 0.4)',
+          'fill-outline-color': '#000'
+        }
+      })
+
+      // Change the cursor to a pointer when the mouse is over the places layer.
+      map.on('mouseenter', 'table', function () {
+        map.getCanvas().style.cursor = 'pointer'
+      })
+
+      // Change it back to a pointer when it leaves.
+      map.on('mouseleave', 'table', function () {
+        map.getCanvas().style.cursor = ''
+      })
+
+      map.on('click', 'table', function (e) {
+        props = e.features[0].properties;
+        t = '<table>';
+        for (var key in props){
+          t += "<tr><td>" + key + "</td><td>" + props[key] + "</td></tr>";
+        }
+        t += '</table>';
+        new mapboxgl.Popup()
+          .setLngLat(e.lngLat)
+          .setHTML(t)
+          .addTo(map);
+      })
+
+
+    })
+  </script>
+
+</body>
+
+</html>

--- a/timvt/templates/factory.py
+++ b/timvt/templates/factory.py
@@ -1,10 +1,14 @@
 """TiVTiler: Template Factory."""
 
 import os
-from typing import Callable
+from typing import Callable, Dict
 
 from starlette.requests import Request
 from starlette.templating import Jinja2Templates, _TemplateResponse
+
+import logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 html_templates = Jinja2Templates(directory=os.path.dirname(__file__))
 
@@ -12,15 +16,16 @@ html_templates = Jinja2Templates(directory=os.path.dirname(__file__))
 def web_template() -> Callable[[Request, str], _TemplateResponse]:
     """Create a dependency which may be injected into a FastAPI app."""
 
-    def _template(request: Request, page: str) -> _TemplateResponse:
+    def _template(
+        request: Request,
+        page: str,
+        context: Dict = {},
+    ) -> _TemplateResponse:
         """Create a template from a request"""
-
-        scheme = request.url.scheme
-        host = request.headers["host"]
-
+        context['request'] = request
         return html_templates.TemplateResponse(
             name=page,
-            context={"request": request, "tile_endpoint": f"{scheme}://{host}/tiles"},
+            context=context,
             media_type="text/html",
         )
 

--- a/timvt/templates/index.html
+++ b/timvt/templates/index.html
@@ -4,87 +4,16 @@
 <head>
   <meta charset='utf-8' />
   <title>Ti VTiler</title>
-  <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.css' rel='stylesheet' />
-
-  <link href='https://api.mapbox.com/mapbox-assembly/v0.23.2/assembly.min.css' rel='stylesheet'>
-  <script src='https://api.mapbox.com/mapbox-assembly/v0.23.2/assembly.js'></script>
-
-  <style>
-    body {
-      margin: 0;
-      padding: 0;
-      width: 100%;
-      height: 100%;
-    }
-
-    #map {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      width: 100%;
-    }
-  </style>
 </head>
 
 <body>
-  <div id='map'></div>
-
-  <script>
-
-    const endpoint = '{{ tile_endpoint }}'
-
-    var scope = { metadata: {}, config: {} }
-
-    var map = new mapboxgl.Map({
-      container: 'map',
-      style: { version: 8, sources: {}, layers: [] },
-      center: [0, 0],
-      zoom: 4
-    })
-
-    map.on('load', () => {
-      map.addSource('countries', {
-        type: 'vector',
-        tiles:[
-          `${endpoint}/countries/{z}/{x}/{y}.pbf`
-        ],
-        minzoom: 4,
-        maxzoom: 24
-      })
-      map.addLayer({
-        id: 'countries',
-        source: 'countries',
-        'source-layer': 'default',
-        type: 'fill',
-        paint: {
-          'fill-color': 'rgba(200, 100, 240, 0.4)',
-          'fill-outline-color': '#000'
-        }
-      })
-
-      // Change the cursor to a pointer when the mouse is over the places layer.
-      map.on('mouseenter', 'countries', function () {
-        map.getCanvas().style.cursor = 'pointer'
-      })
-
-      // Change it back to a pointer when it leaves.
-      map.on('mouseleave', 'countries', function () {
-        map.getCanvas().style.cursor = ''
-      })
-
-      map.on('click', 'countries', function (e) {
-        new mapboxgl.Popup()
-          .setLngLat(e.lngLat)
-          .setHTML(e.features[0].properties.brk_name)
-          .addTo(map);
-      })
-
-
-    })
-  </script>
+<ul>
+    <li><a href="docs">OpenAPI Documentation</a></li>
+    <li><a href="index">JSON Catalog</a></li>
+    {% for t in index %}
+    <li><a href="demo/{{ t.table }}/">Demo for {{ t.table }}</a></li>
+    {% endfor %}
+</ul>
 
 </body>
 

--- a/timvt/utils/catalog.py
+++ b/timvt/utils/catalog.py
@@ -1,0 +1,83 @@
+"""TiVTiler.utils.dependencies: endpoint's dependencies."""
+
+from enum import Enum
+import json
+
+from fastapi import FastAPI
+
+
+class Catalog:
+    def __init__(self, app: FastAPI):
+        self.app = app
+
+    async def init(self):
+        self.index = await self.get_index()
+        self.Tables = self.get_tables_enum()
+
+    @property
+    def sql(self):
+        return """
+            WITH geo_tables AS (
+                SELECT
+                    f_table_schema,
+                    f_table_name,
+                    f_geometry_column
+                FROM
+                    geometry_columns
+            ), t AS (
+            SELECT
+                f_table_schema,
+                f_table_name,
+                f_geometry_column,
+                jsonb_object(
+                    array_agg(column_name),
+                    array_agg(udt_name)
+                ) as coldict
+            FROM
+                information_schema.columns,
+                geo_tables
+            WHERE
+                f_table_schema=table_schema
+                AND
+                f_table_name=table_name
+            GROUP BY
+                f_table_schema,
+                f_table_name,
+                f_geometry_column
+            )
+            SELECT
+                jsonb_agg(
+                    jsonb_build_object(
+                        'schema', f_table_schema,
+                        'table', f_table_name,
+                        'geometry_column', f_geometry_column,
+                        'columns', coldict
+                    )
+                )
+            FROM t
+            ;
+        """
+
+    async def get_index(self):
+        async with self.app.state.pool.acquire() as conn:
+            q = await conn.prepare(self.sql)
+            content = await q.fetchval()
+        self.index = json.loads(content)
+        return self.index
+
+    def get_table(self, table: str):
+        schema = None
+        split = table.split(".")
+        if len(split) == 2:
+            schema = split[0]
+            table = split[1]
+        for r in self.index:
+            if r["table"] == table:
+                if schema is None or r["schema"] == schema:
+                    return r
+        return None
+
+    def get_tables_enum(self):
+        table_list = [r["table"] for r in self.index]
+        Tables = Enum("Tables", [(a, a) for a in table_list])
+        return Tables

--- a/timvt/utils/dependencies.py
+++ b/timvt/utils/dependencies.py
@@ -1,7 +1,6 @@
 """TiVTiler.utils.dependencies: endpoint's dependencies."""
 
 from enum import Enum
-
 import morecantile
 from asyncpg.pool import Pool
 
@@ -13,7 +12,9 @@ from starlette.requests import Request
 
 morecantile.tms.register(custom_tms.EPSG3413)
 
-TileMatrixSetNames = Enum("TileMatrixSetNames", [(a, a) for a in sorted(morecantile.tms.list())])  # type: ignore
+TileMatrixSetNames = Enum(
+    "TileMatrixSetNames", [(a, a) for a in sorted(morecantile.tms.list())]
+)  # type: ignore
 
 
 class TileParams:


### PR DESCRIPTION
Adds a /index endpoint that shows all available layers.

Uses this endpoint in tile requests to:
- Validate table names
- Set geometry column name

Adds columns parameter that takes a comma delimited list of column names to limit the attribute data delivered with the vector tile.

Adds demo for every geo table found.

This also cleans up parameters used in the tile query to avoid sql injection.

This PR addresses issues #10, #11, and #7 

