### PR TITLE
bump asyncpg version to account for fix in buildpg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ with open("README.md") as f:
     long_description = f.read()
 
 inst_reqs = [
-    "asyncpg==0.21.0",
-    "buildpg",
+    "asyncpg>=0.23.0",
+    "buildpg>=0.3",
     "fastapi==0.63.0",
     "jinja2>=2.11.2,<3.0.0",
     "morecantile>=2.1,<2.2",


### PR DESCRIPTION
Fixes #50 

Hi @vincentsarago, I think the original issue has been resolved in buildpg now supporting asyncpg > 0.22.0 See 

- https://github.com/samuelcolvin/buildpg/pull/30
- https://github.com/samuelcolvin/buildpg/pull/32

Currently, tests fail since buildpg now supports the `record_class` keyword while `asyncpg==0.21.0` does not