### PR TITLE
Fixed minor quoting issue in README and corrected dir name in CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Issues and pull requests are more than welcome: https://github.com/developmentse
 
 ```bash
 $ git clone https://github.com/developmentseed/timvt.git
-$ cd titiler
+$ cd timvt
 $ pip install -e .[dev]
 ```
 
@@ -22,7 +22,7 @@ $ pre-commit install
 
 ```bash
 $ git clone https://github.com/developmentseed/timvt.git
-$ cd titiler
+$ cd timvt
 $ pip install -e .["docs"]
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ While we encourage users to write their own application using `TiMVT` package, w
 
 ```bash
 # Install timvt dependencies and Uvicorn (a lightning-fast ASGI server)
-$ pip install timvt uvicorn[standard]>=0.12.0,<0.14.0
+$ pip install timvt 'uvicorn[standard]>=0.12.0,<0.14.0'
 
 # Set Database URL environment variable so TiMVT can access it
 $ export DATABASE_URL=postgresql://username:password@0.0.0.0:5432/postgis


### PR DESCRIPTION
First off all, may I say what a nice project this. I love it. Thanks for all the work you folks do ❤️.

This PR addresses the minor issue that I found while following the README.

```
$ pip install timvt uvicorn[standard]>=0.12.0,<0.14.0
-bash: 0.14.0: No such file or directory

I think, a bit of quoting should fix it.
$ pip install timvt 'uvicorn[standard]>=0.12.0,<0.14.0'
Requirement already satisfied: timvt in ./.env/lib/python3.7/site-packages (0.1.0)
Collecting uvicorn[standard]<0.14.0,>=0.12.0
...
```

I also found that it is mentioned `cd titiler` instead of `cd timvt` in the `CONTRIBUTING.md`. I assumed that was typo and fixed it as well. I hope this is fine. Thank you :)