### PR TITLE
deprecate the use of .pbf and better db settings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## Unreleased
+
+* update database settings input
+* add `default_tms` in Layer definition to specify the Min/Max zoom TileMatrixSet
+
+**breaking changes**
+
+* deprecating the use of `.pbf` in tile's path
+
 ## 0.6.0 (2022-04-14)
 
 * update `morecantile` requirement to `>3.1,=<4.0`

--- a/tests/routes/test_tiles.py
+++ b/tests/routes/test_tiles.py
@@ -40,12 +40,12 @@ def test_tilejson(app):
 
 def test_tile(app):
     """request a tile."""
-    response = app.get("/tiles/public.landsat_wrs/0/0/0.pbf")
+    response = app.get("/tiles/public.landsat_wrs/0/0/0")
     assert response.status_code == 200
     decoded = mapbox_vector_tile.decode(response.content)
     assert len(decoded["default"]["features"]) == 10000
 
-    response = app.get("/tiles/public.landsat_wrs/0/0/0.pbf?limit=1000")
+    response = app.get("/tiles/public.landsat_wrs/0/0/0?limit=1000")
     assert response.status_code == 200
     decoded = mapbox_vector_tile.decode(response.content)
     assert len(decoded["default"]["features"]) == 1000
@@ -53,9 +53,7 @@ def test_tile(app):
         decoded["default"]["features"][0]["properties"]
     )
 
-    response = app.get(
-        "/tiles/public.landsat_wrs/0/0/0.pbf?limit=1&columns=pr,row,path"
-    )
+    response = app.get("/tiles/public.landsat_wrs/0/0/0?limit=1&columns=pr,row,path")
     assert response.status_code == 200
     decoded = mapbox_vector_tile.decode(response.content)
     assert ["pr", "row", "path"] == list(
@@ -65,12 +63,12 @@ def test_tile(app):
 
 def test_tile_tms(app):
     """request a tile with specific TMS."""
-    response = app.get("/tiles/WorldCRS84Quad/public.landsat_wrs/0/0/0.pbf")
+    response = app.get("/tiles/WorldCRS84Quad/public.landsat_wrs/0/0/0")
     assert response.status_code == 200
     decoded = mapbox_vector_tile.decode(response.content)
     assert len(decoded["default"]["features"]) > 1000
 
-    response = app.get("/tiles/WorldCRS84Quad/public.landsat_wrs/0/0/0.pbf?limit=1000")
+    response = app.get("/tiles/WorldCRS84Quad/public.landsat_wrs/0/0/0?limit=1000")
     assert response.status_code == 200
     decoded = mapbox_vector_tile.decode(response.content)
     assert len(decoded["default"]["features"]) <= 1000
@@ -79,7 +77,7 @@ def test_tile_tms(app):
     )
 
     response = app.get(
-        "/tiles/WorldCRS84Quad/public.landsat_wrs/0/0/0.pbf?limit=1&columns=pr,row,path"
+        "/tiles/WorldCRS84Quad/public.landsat_wrs/0/0/0?limit=1&columns=pr,row,path"
     )
     assert response.status_code == 200
     decoded = mapbox_vector_tile.decode(response.content)
@@ -116,12 +114,12 @@ def test_function_tilejson(app):
 
 def test_function_tile(app):
     """request a tile."""
-    response = app.get("/tiles/squares/0/0/0.pbf")
+    response = app.get("/tiles/squares/0/0/0")
     assert response.status_code == 200
     decoded = mapbox_vector_tile.decode(response.content)
     assert len(decoded["default"]["features"]) == 4
 
-    response = app.get("/tiles/squares/0/0/0.pbf?depth=4")
+    response = app.get("/tiles/squares/0/0/0?depth=4")
     assert response.status_code == 200
     decoded = mapbox_vector_tile.decode(response.content)
     assert len(decoded["default"]["features"]) == 16

--- a/timvt/dependencies.py
+++ b/timvt/dependencies.py
@@ -3,36 +3,41 @@
 import re
 from enum import Enum
 
-import morecantile
+from morecantile import Tile, TileMatrixSet, tms
 
 from timvt.layer import Layer, Table
+from timvt.settings import TileSettings
 
 from fastapi import HTTPException, Path, Query
 
 from starlette.requests import Request
 
+tile_settings = TileSettings()
+
 TileMatrixSetNames = Enum(  # type: ignore
-    "TileMatrixSetNames", [(a, a) for a in sorted(morecantile.tms.list())]
+    "TileMatrixSetNames", [(a, a) for a in sorted(tms.list())]
 )
+
+default_tms = TileMatrixSetNames[tile_settings.default_tms]
 
 
 def TileMatrixSetParams(
     TileMatrixSetId: TileMatrixSetNames = Query(
-        TileMatrixSetNames.WebMercatorQuad,  # type: ignore
-        description="TileMatrixSet Name (default: 'WebMercatorQuad')",
+        default_tms,
+        description=f"TileMatrixSet Name (default: '{tile_settings.default_tms}')",
     ),
-) -> morecantile.TileMatrixSet:
+) -> TileMatrixSet:
     """TileMatrixSet parameters."""
-    return morecantile.tms.get(TileMatrixSetId.name)
+    return tms.get(TileMatrixSetId.name)
 
 
 def TileParams(
     z: int = Path(..., ge=0, le=30, description="Tiles's zoom level"),
     x: int = Path(..., description="Tiles's column"),
     y: int = Path(..., description="Tiles's row"),
-) -> morecantile.Tile:
+) -> Tile:
     """Tile parameters."""
-    return morecantile.Tile(x, y, z)
+    return Tile(x, y, z)
 
 
 def LayerParams(

--- a/timvt/layer.py
+++ b/timvt/layer.py
@@ -25,6 +25,7 @@ class Layer(BaseModel, metaclass=abc.ABCMeta):
         bounds (list): Layer's bounds (left, bottom, right, top).
         minzoom (int): Layer's min zoom level.
         maxzoom (int): Layer's max zoom level.
+        default_tms (str): TileMatrixSet name for the min/max zoom.
         tileurl (str, optional): Layer's tiles url.
 
     """
@@ -33,6 +34,7 @@ class Layer(BaseModel, metaclass=abc.ABCMeta):
     bounds: List[float] = [-180, -90, 180, 90]
     minzoom: int = tile_settings.default_minzoom
     maxzoom: int = tile_settings.default_maxzoom
+    default_tms: str = tile_settings.default_tms
     tileurl: Optional[str]
 
     @abc.abstractmethod

--- a/timvt/main.py
+++ b/timvt/main.py
@@ -1,7 +1,7 @@
 """TiVTiler app."""
 
 from timvt import __version__ as timvt_version
-from timvt.db import close_db_connection, connect_to_db
+from timvt.db import close_db_connection, connect_to_db, register_table_catalog
 from timvt.factory import TMSFactory, VectorTilerFactory
 from timvt.layer import FunctionRegistry
 from timvt.settings import ApiSettings
@@ -51,6 +51,7 @@ app.state.function_catalog = FunctionRegistry()
 async def startup_event():
     """Application startup: register the database connection and create table list."""
     await connect_to_db(app)
+    await register_table_catalog(app)
 
 
 @app.on_event("shutdown")

--- a/timvt/settings.py
+++ b/timvt/settings.py
@@ -49,6 +49,7 @@ class _TileSettings(pydantic.BaseSettings):
     tile_resolution: int = 4096
     tile_buffer: int = 256
     max_features_per_tile: int = 10000
+    default_tms: str = "WebMercatorQuad"
     default_minzoom: int = 0
     default_maxzoom: int = 22
 
@@ -65,7 +66,7 @@ def TileSettings() -> _TileSettings:
     return _TileSettings()
 
 
-class _PostgresSettings(pydantic.BaseSettings):
+class PostgresSettings(pydantic.BaseSettings):
     """Postgres-specific API settings.
 
     Attributes:
@@ -97,6 +98,7 @@ class _PostgresSettings(pydantic.BaseSettings):
     # https://github.com/tiangolo/full-stack-fastapi-postgresql/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/backend/app/app/core/config.py#L42
     @pydantic.validator("database_url", pre=True)
     def assemble_db_connection(cls, v: Optional[str], values: Dict[str, Any]) -> Any:
+        """Validate database config."""
         if isinstance(v, str):
             return v
 
@@ -108,16 +110,3 @@ class _PostgresSettings(pydantic.BaseSettings):
             port=values.get("postgres_port", 5432),
             path=f"/{values.get('postgres_dbname') or ''}",
         )
-
-
-@lru_cache()
-def PostgresSettings() -> _PostgresSettings:
-    """
-    This function returns a cached instance of the APISettings object.
-    Caching is used to prevent re-reading the environment every time the API settings are used in an endpoint.
-    If you want to change an environment variable and reset the cache (e.g., during testing), this can be done
-    using the `lru_cache` instance method `get_api_settings.cache_clear()`.
-
-    From https://github.com/dmontagu/fastapi-utils/blob/af95ff4a8195caaa9edaa3dbd5b6eeb09691d9c7/fastapi_utils/api_settings.py#L60-L69
-    """
-    return _PostgresSettings()


### PR DESCRIPTION
This PR does:

- enable customization of db settings as https://github.com/stac-utils/titiler-pgstac/pull/53
- deprecate the use of `.pbf` in tile's path 
