### PR TITLE
only use Table once

### DIFF
--- a/timvt/dbmodel.py
+++ b/timvt/dbmodel.py
@@ -1,6 +1,6 @@
 """timvt.db: database events."""
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from buildpg import asyncpg
 from pydantic import BaseModel, Field
@@ -84,19 +84,11 @@ class Table(BaseModel):
 class Database(BaseModel):
     """Keyed tables for a Database."""
 
-    tables: Dict[str, Table]
+    tables: Dict[str, Any]
 
     def __iter__(self):
         """iterate over features"""
         return iter(self.tables.values())
-
-    def __len__(self):
-        """return features length"""
-        return len(self.tables)
-
-    def __getitem__(self, key):
-        """get table at a given key"""
-        return self.tables[key]
 
 
 async def get_table_index(
@@ -220,7 +212,7 @@ async def get_table_index(
         )
         d = {}
         for row in rows:
-            d[row["id"]] = Table(
+            d[row["id"]] = dict(
                 id=row[0],
                 schema=row[1],
                 table=row[2],

--- a/timvt/dbmodel.py
+++ b/timvt/dbmodel.py
@@ -188,8 +188,8 @@ async def get_table_index(
         )
         SELECT
                 id,
-                schemaname as schema,
-                tablename as table,
+                schemaname as dbschema,
+                tablename as tablename,
                 geometry_columns,
                 pk as id_col,
                 columns as properties,
@@ -203,4 +203,13 @@ async def get_table_index(
         rows = await conn.fetch_b(
             query, schemas=schemas, tables=tables, spatial=spatial
         )
-        return {row["id"]: dict(row) for row in rows}
+        keys = [
+            "id",
+            "schema",
+            "table",
+            "geometry_columns",
+            "id_col",
+            "properties",
+            "description",
+        ]
+        return {row["id"]: dict(zip(keys, tuple(row))) for row in rows}

--- a/timvt/dbmodel.py
+++ b/timvt/dbmodel.py
@@ -81,14 +81,7 @@ class Table(BaseModel):
         return cols
 
 
-class Database(BaseModel):
-    """Keyed tables for a Database."""
-
-    tables: Dict[str, Any]
-
-    def __iter__(self):
-        """iterate over features"""
-        return iter(self.tables.values())
+Database = Dict[str, Dict[str, Any]]
 
 
 async def get_table_index(
@@ -195,8 +188,8 @@ async def get_table_index(
         )
         SELECT
                 id,
-                schemaname as dbschema,
-                tablename as tablename,
+                schemaname as schema,
+                tablename as table,
                 geometry_columns,
                 pk as id_col,
                 columns as properties,
@@ -210,15 +203,4 @@ async def get_table_index(
         rows = await conn.fetch_b(
             query, schemas=schemas, tables=tables, spatial=spatial
         )
-        d = {}
-        for row in rows:
-            d[row["id"]] = dict(
-                id=row[0],
-                schema=row[1],
-                table=row[2],
-                geometry_columns=row[3],
-                id_col=row[4],
-                properties=row[5],
-                description=row[6],
-            )
-    return Database(tables=d)
+        return {row["id"]: dict(row) for row in rows}

--- a/timvt/dependencies.py
+++ b/timvt/dependencies.py
@@ -66,7 +66,7 @@ def LayerParams(
 
         table_catalog = getattr(request.app.state, "table_catalog", [])
         for r in table_catalog:
-            if r.id == layer:
-                return Table(**r.dict(by_alias=True))
+            if r["id"] == layer:
+                return Table(**r)
 
     raise HTTPException(status_code=404, detail=f"Table/Function '{layer}' not found.")

--- a/timvt/dependencies.py
+++ b/timvt/dependencies.py
@@ -64,9 +64,8 @@ def LayerParams(
         assert table_pattern.groupdict()["schema"]
         assert table_pattern.groupdict()["table"]
 
-        table_catalog = getattr(request.app.state, "table_catalog", [])
-        for r in table_catalog:
-            if r["id"] == layer:
-                return Table(**r)
+        table_catalog = getattr(request.app.state, "table_catalog", {})
+        if layer in table_catalog:
+            return Table(**table_catalog[layer])
 
     raise HTTPException(status_code=404, detail=f"Table/Function '{layer}' not found.")

--- a/timvt/factory.py
+++ b/timvt/factory.py
@@ -216,7 +216,7 @@ class VectorTilerFactory:
                     return None
 
             return [
-                Table(**r.dict(by_alias=True), tileurl=_get_tiles_url(r.id))
+                Table(**r, tileurl=_get_tiles_url(r["id"]))
                 for r in request.app.state.table_catalog
             ]
 

--- a/timvt/factory.py
+++ b/timvt/factory.py
@@ -215,9 +215,10 @@ class VectorTilerFactory:
                 except NoMatchFound:
                     return None
 
+            table_catalog = getattr(request.app.state, "table_catalog", {})
             return [
-                Table(**r, tileurl=_get_tiles_url(r["id"]))
-                for r in request.app.state.table_catalog
+                Table(**table_info, tileurl=_get_tiles_url(table_id))
+                for table_id, table_info in table_catalog.items()
             ]
 
         @self.router.get(

--- a/timvt/layer.py
+++ b/timvt/layer.py
@@ -71,11 +71,12 @@ class Table(Layer, DBTable):
         maxzoom (int): Layer's max zoom level.
         tileurl (str, optional): Layer's tiles url.
         type (str): Layer's type.
+        table (str): Table's name.
         schema (str): Table's database schema (e.g public).
-        geometry_type (str): Table's geometry type (e.g polygon).
-        srid (int): Table's SRID
-        geometry_column (str): Name of the geomtry column in the table.
-        properties (Dict): Properties available in the table.
+        description (str): Table's description.
+        id_column (str): name of id column
+        geometry_columns (list): List of geometry columns.
+        properties (list): List of property columns.
 
     """
 

--- a/timvt/layer.py
+++ b/timvt/layer.py
@@ -270,7 +270,7 @@ class Function(Layer):
                     ":xmax",
                     ":ymax",
                     ":epsg",
-                    ":query_params",
+                    ":query_params::text::json",
                 ),
             )
             q, p = render(

--- a/timvt/main.py
+++ b/timvt/main.py
@@ -75,9 +75,10 @@ app.include_router(tms.router, tags=["TileMatrixSets"])
 @app.get("/", response_class=HTMLResponse, include_in_schema=False)
 async def index(request: Request):
     """DEMO."""
+    table_catalog = getattr(request.app.state, "table_catalog", {})
     return templates.TemplateResponse(
         name="index.html",
-        context={"index": request.app.state.table_catalog, "request": request},
+        context={"index": table_catalog.values(), "request": request},
         media_type="text/html",
     )
 


### PR DESCRIPTION
This PR change the way we create the `Table` object. in #83 we were first creating a `dbmodel.Table` and then passing it (using `table.dict()`) to `layer.Table`. This result in useless double validation (slow down application)


To be discussed

cc @bitner 