### PR TITLE
check endswith[] first, otherwise it will never be caught

### DIFF
--- a/timvt/dbmodel.py
+++ b/timvt/dbmodel.py
@@ -18,6 +18,9 @@ class Column(BaseModel):
         """Return JSON field type."""
         pgtype = self.type
 
+        if pgtype.endswith("[]"):
+            return "array"
+
         if any(
             [
                 pgtype.startswith("int"),
@@ -29,9 +32,6 @@ class Column(BaseModel):
 
         if pgtype.startswith("bool"):
             return "boolean"
-
-        if pgtype.endswith("[]"):
-            return "array"
 
         if any([pgtype.startswith("json"), pgtype.startswith("geo")]):
             return "object"


### PR DESCRIPTION
When calculating the json type from a postgres type, change order of if statements. Currently, if the postgres type was a text array "text[]" it would never reach the array test.
